### PR TITLE
Feature: Support disposition attachment 

### DIFF
--- a/lib/fileboost/helpers.rb
+++ b/lib/fileboost/helpers.rb
@@ -5,7 +5,7 @@ module Fileboost
     # Generate an optimized image tag using Fileboost
     #
     # @param asset [ActiveStorage::Blob, ActiveStorage::Attached, ActiveStorage::VariantWithRecord] The ActiveStorage image asset
-    # @param options [Hash] Image transformation and HTML options
+    # @param options [Hash] Accepts a `:resize` hash for transformations plus standard HTML options
     # @return [String] HTML image tag
     #
     # Examples:
@@ -25,7 +25,7 @@ module Fileboost
     # Generate an optimized URL using Fileboost
     #
     # @param asset [ActiveStorage::Blob, ActiveStorage::Attached, ActiveStorage::VariantWithRecord] The ActiveStorage image asset
-    # @param options [Hash] Image transformation options
+    # @param options [Hash] Supports a `:resize` hash for image transformations and an optional `:disposition`
     # @return [String, nil] The optimized URL or nil if generation failed
     #
     # Examples:

--- a/lib/fileboost/url_builder.rb
+++ b/lib/fileboost/url_builder.rb
@@ -118,6 +118,11 @@ module Fileboost
         end
       end
 
+      disposition = options[:disposition] || options["disposition"]
+      if disposition.present?
+        params["disposition"] = disposition.to_s.strip.downcase
+      end
+
       params
     end
 

--- a/lib/fileboost/url_builder.rb
+++ b/lib/fileboost/url_builder.rb
@@ -45,7 +45,10 @@ module Fileboost
       # Extract and normalize transformation parameters
       transformation_params = extract_transformation_params(asset, options)
 
-      # Generate HMAC signature for secure authentication
+      # Separate disposition from transformation params for signature generation
+      disposition = transformation_params.delete("disposition")
+
+      # Generate HMAC signature for secure authentication (excluding disposition)
       signature = Fileboost::SignatureGenerator.generate(
         asset_path: asset_path,
         params: transformation_params
@@ -53,8 +56,9 @@ module Fileboost
 
       raise SignatureGenerationError, "Failed to generate signature" unless signature
 
-      # Add signature to parameters
+      # Add signature and disposition back to final URL parameters
       all_params = transformation_params.merge("sig" => signature)
+      all_params["disposition"] = disposition if disposition
 
       # Build final URL
       uri = URI.join(base_url, full_path)

--- a/spec/fileboost/helpers_spec.rb
+++ b/spec/fileboost/helpers_spec.rb
@@ -60,6 +60,12 @@ RSpec.describe Fileboost::Helpers do
       expect(url).to include("fit=scale-down")
     end
 
+    it "includes disposition parameter when provided" do
+      url = fileboost_url_for(blob, disposition: :attachment)
+
+      expect(url).to include("disposition=attachment")
+    end
+
     it "raises ArgumentError for invalid asset type" do
       expect {
         fileboost_url_for("invalid", resize: { w: 300 })

--- a/spec/fileboost/url_builder_spec.rb
+++ b/spec/fileboost/url_builder_spec.rb
@@ -150,5 +150,24 @@ RSpec.describe Fileboost::UrlBuilder do
         expect(url).to include("fit=scale-down")
       end
     end
+
+    context "with disposition parameter" do
+      it "includes disposition in URL but excludes from signature generation" do
+        # Generate URLs with and without disposition
+        url_without_disposition = Fileboost::UrlBuilder.build_url(blob, resize: { w: 300 })
+        url_with_disposition = Fileboost::UrlBuilder.build_url(blob, resize: { w: 300 }, disposition: "attachment")
+
+        # Extract signatures from both URLs
+        sig_without = URI.decode_www_form(URI.parse(url_without_disposition).query).to_h["sig"]
+        sig_with = URI.decode_www_form(URI.parse(url_with_disposition).query).to_h["sig"]
+
+        # Signatures should be identical (disposition not affecting signature)
+        expect(sig_without).to eq(sig_with)
+
+        # But the URL with disposition should include the disposition parameter
+        expect(url_with_disposition).to include("disposition=attachment")
+        expect(url_without_disposition).not_to include("disposition=")
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR introduces support for `disposition: "attachment"` that would tell the browser to download the file instead of rendering it inline. 